### PR TITLE
Little updates in order to keep compatibility with newer systems.

### DIFF
--- a/exploit.py
+++ b/exploit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import struct
 import os

--- a/ropeme/gadgets.py
+++ b/ropeme/gadgets.py
@@ -18,8 +18,13 @@
 #       MA 02110-1301, USA.
 
 import trie
-import distorm
 import sys
+
+try:
+    import distorm
+except:
+    import distorm3 as distorm
+
 try:
     import cPickle as pickle
 except:

--- a/ropeme/gen-gadgets.py
+++ b/ropeme/gen-gadgets.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #       gen-gadgets.py
 #       
 #       Copyright 2010 Long Le Dinh <longld at vnsecurity.net>

--- a/ropeme/payload.py
+++ b/ropeme/payload.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #       payload.py
 #       
 #       Copyright 2010 Long Le Dinh <longld at vnsecurity.net>

--- a/ropeme/readelf.py
+++ b/ropeme/readelf.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #
 #       readelf.py
 #

--- a/ropeme/ropsearch.py
+++ b/ropeme/ropsearch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #       ropsearch.py
 #       
 #       Copyright 2010 Long Le Dinh <longld at vnsecurity.net>

--- a/ropeme/ropshell.py
+++ b/ropeme/ropshell.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #       ropshell.py
 #       
 #       Copyright 2010 Long Le Dinh <longld at vnsecurity.net>

--- a/ropeme/search-gadgets.py
+++ b/ropeme/search-gadgets.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 #       search-gadgets.py
 #       
 #       Copyright 2010 Long Le Dinh <longld at vnsecurity.net>

--- a/ropeme/trie.py
+++ b/ropeme/trie.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # This code was borrowed from gDesklets
 


### PR DESCRIPTION
Those updates are juste very light fixes, ensuring a full non-regression, but allowing newer environments to correctly handle this wonderful tool.
- Using `python2` as shebang loader, instead of `python` (which nowadays may be `python3`)
- Trying to import `distorm3`, when `distorm` module is unavailable
